### PR TITLE
quit with fatal error when no module is started

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,6 @@ type module interface {
 
 func main() {
 	flag.Parse()
-	log.Printf("Hello world")
 
 	if *masterGenKeys {
 		if err := genMasterKeys(); err != nil {
@@ -89,8 +88,10 @@ func main() {
 	}
 
 	if len(mods) == 0 {
-		ret <- errors.New("You need to specify either --master_port or --master")
+		err := errors.New("You need to specify either --master_port or --master")
+		log.Fatalln(err)
 	}
+
 	for _, m := range mods {
 		if err := m.Setup(); err != nil {
 			log.Fatalln(err)


### PR DESCRIPTION
When `--master-port` and `--master` are both not specified, no module will be started. Because of this, the error will not be printed [further in the code](https://github.com/Jille/rufs/blob/7988412aa530a0969e08e8d3caf7e3081175f2b3/main.go#L127-L135). It's probably better (is it?) to fail with a fatal error. In this case, nothing interesting will happen anyway.
